### PR TITLE
hidden channels: center ui, add image, and edit text styles

### DIFF
--- a/plugins/hiddenChannels/assets/Notice.jsx
+++ b/plugins/hiddenChannels/assets/Notice.jsx
@@ -4,8 +4,8 @@ const {
 
 import classes from "./style.scss";
 
-import LockedChannelIcon from "./LockedChannelIcon.jsx";
 import ChannelTopic from "./ChannelTopic.jsx";
+import LockedChannelIcon from "./LockedChannelIcon.jsx";
 
 export default (props) => {
    return (
@@ -25,11 +25,20 @@ export default (props) => {
             </ReactInSolidBridge>
             <div class={classes.mainBody}>
                <div class={classes.chat}>
-                  <Header tag={HeaderTags.H2}>This is a hidden channel.</Header>
-                  <Header tag={HeaderTags.H5}>
-                     You cannot see the contents of this channel. However, you
-                     may see its name and topic.
-                  </Header>
+                  <img
+                     src="https://discord.com/assets/9b1b9ee4868c262e7351.svg"
+                     alt="Hidden channel"
+                     class={classes.hiddenChannelImage}
+                  />
+                  <div class={classes.hiddenChannelTextContainer}>
+                     <p class={classes.hiddenChannelText}>
+                        This is a hidden channel.
+                     </p>
+                     <p class={classes.hiddenChannelSubText}>
+                        You cannot see the contents of this channel. However, you
+                        may see its name and topic.
+                     </p>
+                  </div>
                </div>
             </div>
          </div>

--- a/plugins/hiddenChannels/assets/style.scss
+++ b/plugins/hiddenChannels/assets/style.scss
@@ -16,6 +16,39 @@ shltr-rroot > svg > path[d^="M19"][d$="7Z"]  // NSFW in header
    fill: #ed4245 !important;
 }
 
+
+.hiddenChannelImage {
+   width: 40rem;
+   margin-bottom: 1rem;
+}
+
+.hiddenChannelText {
+   text-transform: uppercase;
+   color: var(--text-normal);
+   font-size: 2rem;
+   font-weight: 600;
+   padding: 0;
+   margin: 0;
+}
+
+.hiddenChannelSubText {
+   text-transform: uppercase;
+   color: var(--text-muted);
+   font-size: 1rem;
+   font-weight: 400;
+   padding: 0;
+   margin: 0;
+}
+
+.hiddenChannelTextContainer {
+   display: flex;
+   flex-direction: column;
+   align-items: center;
+   justify-content: center;
+   gap: 0.5rem;
+   margin-top: -0.25rem; // The image is a bit too high even with 0 margin
+}
+
 .divider {
    width: 1px;
    height: 24px;
@@ -62,6 +95,8 @@ shltr-rroot > svg > path[d^="M19"][d$="7Z"]  // NSFW in header
       z-index: 1;
       pointer-events: none;
    }
+
+   padding-bottom: 16rem;
 }
 
 .chat {
@@ -73,4 +108,6 @@ shltr-rroot > svg > path[d^="M19"][d$="7Z"]  // NSFW in header
    justify-content: center;
    align-items: center;
    height: 100vh;
+   gap: 0rem;
+   margin-top: -4rem;
 }


### PR DESCRIPTION
- Adjusted .hiddenChannelImage width and margin
- Updated .hiddenChannelText styles for better readability
- Included color variable for text normalization

Before and after screenshots included for reference.

Before:
![image](https://github.com/user-attachments/assets/13a6abbf-1a93-4af2-b1af-d1e26f16e734)
After
![image](https://github.com/user-attachments/assets/778e803e-9e61-47d4-a083-2dbc62473725)
